### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,5 +1,8 @@
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/TownSuite/TownSuite.Prometheus.FileSdConfigs/security/code-scanning/10](https://github.com/TownSuite/TownSuite.Prometheus.FileSdConfigs/security/code-scanning/10)

In general, the fix is to add an explicit `permissions` block that grants only the minimal required permissions for the `GITHUB_TOKEN`. For this workflow, the jobs only need to read repository contents (for `actions/checkout`) and do not interact with issues, pull requests, or other write APIs. The recommended minimal starting point is `permissions: contents: read` at the workflow (top) level so it applies to all jobs.

Concretely, in `.github/workflows/dotnet.yml`, add a `permissions` block after the `name: .NET` line (before `on:`). This will set default permissions for all three jobs (`linux-build`, `windows-build`, and `mac-build`). No per‑job overrides are needed, and no other changes to steps or actions are required. No imports or extra definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
