### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -4,6 +4,10 @@ on:
     workflows: [".NET"] # runs after .NET workflow
     types:
       - completed
+permissions:
+  contents: read
+  actions: read
+  checks: write
 jobs:
   report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TownSuite/TownSuite.Prometheus.FileSdConfigs/security/code-scanning/8](https://github.com/TownSuite/TownSuite.Prometheus.FileSdConfigs/security/code-scanning/8)

In general, the fix is to add an explicit `permissions` block to the workflow (at the root or per job) that grants only the scopes required. For this workflow, the `dorny/test-reporter@v2` action reads test result artifacts and creates a check run on the commit; that requires read access to `contents` and write access to `checks` (not `contents`), and potentially read access to `actions` to download artifacts. We should therefore restrict the token to read for `contents` and `actions`, and write only for `checks`.

The single best fix without changing existing functionality is to add a top-level `permissions` block (applies to all jobs) just under the workflow `name:` and `on:` section. This keeps behavior the same (the action can still create the check run) while reducing unnecessary privileges and clearly documenting the required scopes. No imports or additional files are needed; we only edit `.github/workflows/test-report.yml`, adding the YAML `permissions` mapping near the top.

Concretely:
- In `.github/workflows/test-report.yml`, insert:

```yaml
permissions:
  contents: read
  actions: read
  checks: write
```

between the `on:` block and the `jobs:` block. No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
